### PR TITLE
Added #define guard for stb_image globals

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -12,7 +12,7 @@ solution "nanovg"
 		includedirs { "src" }
 		files { "src/*.c" }
 		targetdir("build")
-		defines { "_CRT_SECURE_NO_WARNINGS" } --,"FONS_USE_FREETYPE" } Uncomment to compile with FreeType support
+		defines { "_CRT_SECURE_NO_WARNINGS", "NVG_STB_IMAGE_IMPLEMENTATION" } --,"FONS_USE_FREETYPE" } Uncomment to compile with FreeType support
 		
 		configuration "Debug"
 			defines { "DEBUG" }

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -24,7 +24,10 @@
 #include "nanovg.h"
 #define FONTSTASH_IMPLEMENTATION
 #include "fontstash.h"
+
+#ifdef NVG_STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_IMPLEMENTATION
+#endif
 #include "stb_image.h"
 
 #ifdef _MSC_VER


### PR DESCRIPTION
I am upstreaming some of the changes my team has made to nanovg and nanogui.

The following code causes stb_image to deposit global data structures in intermediate linked object files.
```
#define STB_IMAGE_IMPLEMENTATION
#include "stb_image.h"
```

We have other libraries that depend on stb_image, which causes duplicate symbol failures upon linking a final library or binary target.

We fixed this problem by guarding the definition of `STD_IMAGE_IMPLEMENTATION` behind an optional build-time switch.